### PR TITLE
Fix card flip English orientation

### DIFF
--- a/codexTestApp/CardView.swift
+++ b/codexTestApp/CardView.swift
@@ -29,7 +29,11 @@ struct CardView: View {
                     .foregroundColor(.black)
             }
             .opacity(flipped ? 1 : 0)
-            .rotation3DEffect(.degrees(flipped ? 0 : -180), axis: (x:0, y:1, z:0))
+            // Rotate the English side an additional 180° when flipped so it reads correctly
+            .rotation3DEffect(
+                .degrees(flipped ? 180 : -180),
+                axis: (x: 0, y: 1, z: 0)
+            )
         }
         .frame(width: 300, height: 200)
         .rotation3DEffect(.degrees(flipped ? 180 : 0), axis: (x:0, y:1, z:0))


### PR DESCRIPTION
## Summary
- ensure flipped English text is right-side up by rotating it an additional 180 degrees

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `swiftc codexTestApp/CardView.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_684cf67dced48330a877607d85877ae5