### PR TITLE
Improve flashcard UI with scoring

### DIFF
--- a/codexTestApp/CardView.swift
+++ b/codexTestApp/CardView.swift
@@ -2,31 +2,51 @@ import SwiftUI
 
 struct CardView: View {
     var card: Flashcard
-    var onRemoval: () -> Void
+    /// Callback when the card is swiped away. `true` means the user knew the
+    /// word (swiped right) and `false` means they did not (swiped left).
+    var onRemoval: (Bool) -> Void
 
     @State private var flipped = false
     @State private var offset: CGSize = .zero
 
     var body: some View {
         ZStack {
+            // Spanish side
             Group {
                 RoundedRectangle(cornerRadius: 20)
-                    .fill(Color.white)
+                    .fill(.ultraThinMaterial)
+                    .background(
+                        LinearGradient(
+                            colors: [.blue.opacity(0.6), .purple.opacity(0.6)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 20))
                     .shadow(radius: 5)
                 Text(card.spanish)
-                    .font(.largeTitle)
-                    .foregroundColor(.black)
+                    .font(.largeTitle.weight(.bold))
+                    .foregroundColor(.white)
             }
             .opacity(flipped ? 0 : 1)
             .rotation3DEffect(.degrees(flipped ? 180 : 0), axis: (x:0, y:1, z:0))
 
+            // English side
             Group {
                 RoundedRectangle(cornerRadius: 20)
-                    .fill(Color.white)
+                    .fill(.ultraThinMaterial)
+                    .background(
+                        LinearGradient(
+                            colors: [.purple.opacity(0.6), .blue.opacity(0.6)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 20))
                     .shadow(radius: 5)
                 Text(card.english)
-                    .font(.largeTitle)
-                    .foregroundColor(.black)
+                    .font(.largeTitle.weight(.bold))
+                    .foregroundColor(.white)
             }
             .opacity(flipped ? 1 : 0)
             // Rotate the English side an additional 180° when flipped so it reads correctly
@@ -44,13 +64,14 @@ struct CardView: View {
                 .onChanged { offset = $0.translation }
                 .onEnded { value in
                     if abs(value.translation.width) > 100 {
+                        let knewWord = value.translation.width > 0
                         withAnimation {
-                            offset.width = value.translation.width > 0 ? 1000 : -1000
+                            offset.width = knewWord ? 1000 : -1000
                         }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                             offset = .zero
                             flipped = false
-                            onRemoval()
+                            onRemoval(knewWord)
                         }
                     } else {
                         withAnimation { offset = .zero }
@@ -62,5 +83,5 @@ struct CardView: View {
 }
 
 #Preview {
-    CardView(card: Flashcard(spanish: "hola", english: "hello")) {}
+    CardView(card: Flashcard(spanish: "hola", english: "hello")) { _ in }
 }

--- a/codexTestApp/DeckView.swift
+++ b/codexTestApp/DeckView.swift
@@ -3,16 +3,39 @@ import SwiftUI
 struct DeckView: View {
     var deck: Deck
     @State private var index: Int = 0
+    @State private var correctCount: Int = 0
+    @State private var wrongCount: Int = 0
 
     var body: some View {
-        VStack {
+        VStack(spacing: 20) {
             if index < deck.cards.count {
-                CardView(card: deck.cards[index]) {
+                Text("Card \(index + 1) of \(deck.cards.count)")
+                    .font(.headline)
+
+                ProgressView(value: Double(index), total: Double(deck.cards.count))
+                    .padding(.horizontal)
+
+                CardView(card: deck.cards[index]) { knew in
+                    if knew {
+                        correctCount += 1
+                    } else {
+                        wrongCount += 1
+                    }
                     withAnimation { index += 1 }
                 }
             } else {
-                Text("Finished!")
-                    .font(.largeTitle)
+                VStack(spacing: 12) {
+                    Text("Finished!")
+                        .font(.largeTitle)
+                    Text("Correct: \(correctCount)")
+                    Text("Incorrect: \(wrongCount)")
+                    Button("Restart") {
+                        index = 0
+                        correctCount = 0
+                        wrongCount = 0
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
             }
         }
         .navigationTitle("Cards")

--- a/codexTestApp/HomeView.swift
+++ b/codexTestApp/HomeView.swift
@@ -6,9 +6,9 @@ struct HomeView: View {
 
     var body: some View {
         NavigationView {
-            VStack(spacing: 20) {
+            VStack(spacing: 30) {
                 Text("Spanish Flashcards")
-                    .font(.largeTitle)
+                    .font(.largeTitle.bold())
                     .padding()
 
                 Button("Remake Deck") {
@@ -25,6 +25,16 @@ struct HomeView: View {
                 }
                 .buttonStyle(.bordered)
             }
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(
+                LinearGradient(
+                    colors: [.blue.opacity(0.4), .purple.opacity(0.6)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .ignoresSafeArea()
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- restyle `CardView` with gradients
- track progress and correct/incorrect counts in `DeckView`
- apply gradient background on the home screen

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_684cf6fe323c8330992711f7a5e5304b