### PR TITLE
Enhance home screen with deck options and card list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The main project file is `codexTestApp.xcodeproj` and the sources reside in the
 `codexTestApp` folder.
 
 ## Features
-- Home screen to remake or start a deck of 20 random Spanish/English cards.
+- Adjustable deck size from the Home screen.
+- Generate a new deck of random Spanish/English cards for practice.
+- View a list of all available cards.
 - Tap a card to flip between languages with an animation.
 - Drag a card off screen to move to the next one.
 

--- a/codexTestApp/AllCardsView.swift
+++ b/codexTestApp/AllCardsView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct AllCardsView: View {
+    var body: some View {
+        List(Deck.allCards) { card in
+            HStack {
+                Text(card.spanish)
+                    .font(.headline)
+                Spacer()
+                Text(card.english)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 4)
+        }
+        .navigationTitle("All Cards")
+    }
+}
+
+#Preview {
+    AllCardsView()
+}

--- a/codexTestApp/HomeView.swift
+++ b/codexTestApp/HomeView.swift
@@ -1,32 +1,46 @@
 import SwiftUI
 
 struct HomeView: View {
-    @State private var deck: Deck = Deck.randomDeck()
+    @State private var deckSize: Int = 10
+    @State private var deck: Deck = Deck.randomDeck(size: 10)
     @State private var showDeck = false
-
+    
     var body: some View {
         NavigationView {
-            VStack(spacing: 30) {
-                Text("Spanish Flashcards")
-                    .font(.largeTitle.bold())
-                    .padding()
+            ScrollView {
+                VStack(spacing: 24) {
+                    Text("Spanish Flashcards")
+                        .font(.largeTitle.bold())
+                        .padding(.top)
 
-                Button("Remake Deck") {
-                    deck = Deck.randomDeck()
-                }
-                .buttonStyle(.borderedProminent)
+                    Text("Practice your vocabulary by swiping through cards. Select how many cards you'd like in this session and press Start.")
+                        .multilineTextAlignment(.center)
 
-                NavigationLink(destination: DeckView(deck: deck), isActive: $showDeck) {
-                    EmptyView()
-                }
+                    Stepper("Deck size: \(deckSize)", value: $deckSize, in: 5...Deck.allCards.count, step: 5)
+                        .padding(.horizontal)
 
-                Button("Start") {
-                    showDeck = true
+                    Button("Generate Deck") {
+                        deck = Deck.randomDeck(size: deckSize)
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    NavigationLink(destination: DeckView(deck: deck), isActive: $showDeck) {
+                        EmptyView()
+                    }
+
+                    Button("Start Practice") {
+                        showDeck = true
+                    }
+                    .buttonStyle(.bordered)
+
+                    NavigationLink("View All Cards", destination: AllCardsView())
+                        .padding(.top, 10)
+
+                    Spacer(minLength: 0)
                 }
-                .buttonStyle(.bordered)
+                .padding()
+                .frame(maxWidth: .infinity)
             }
-            .padding()
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(
                 LinearGradient(
                     colors: [.blue.opacity(0.4), .purple.opacity(0.6)],

--- a/codexTestApp/Models.swift
+++ b/codexTestApp/Models.swift
@@ -9,13 +9,13 @@ struct Flashcard: Identifiable {
 struct Deck {
     var cards: [Flashcard]
 
-    static func randomDeck() -> Deck {
-        let allCards: [Flashcard] = [
-            Flashcard(spanish: "hola", english: "hello"),
-            Flashcard(spanish: "adios", english: "goodbye"),
-            Flashcard(spanish: "gracias", english: "thank you"),
-            Flashcard(spanish: "por favor", english: "please"),
-            Flashcard(spanish: "si", english: "yes"),
+    /// Full list of available flashcards.
+    static let allCards: [Flashcard] = [
+        Flashcard(spanish: "hola", english: "hello"),
+        Flashcard(spanish: "adios", english: "goodbye"),
+        Flashcard(spanish: "gracias", english: "thank you"),
+        Flashcard(spanish: "por favor", english: "please"),
+        Flashcard(spanish: "si", english: "yes"),
             Flashcard(spanish: "no", english: "no"),
             Flashcard(spanish: "amigo", english: "friend"),
             Flashcard(spanish: "familia", english: "family"),
@@ -49,11 +49,15 @@ struct Deck {
             Flashcard(spanish: "invierno", english: "winter"),
             Flashcard(spanish: "hoy", english: "today"),
             Flashcard(spanish: "manana", english: "tomorrow"),
-            Flashcard(spanish: "izquierda", english: "left"),
-            Flashcard(spanish: "derecha", english: "right")
+        Flashcard(spanish: "izquierda", english: "left"),
+        Flashcard(spanish: "derecha", english: "right")
         ]
+
+    /// Create a deck with a random subset of the available cards.
+    static func randomDeck(size: Int = 20) -> Deck {
         let shuffled = allCards.shuffled()
-        let selected = Array(shuffled.prefix(20))
+        let clamped = max(1, min(size, allCards.count))
+        let selected = Array(shuffled.prefix(clamped))
         return Deck(cards: selected)
     }
 }


### PR DESCRIPTION
## Summary
- let users adjust the deck size
- add a screen to browse all available flashcards
- update home view UI with more options and description
- document new functionality in README

## Testing
- `swift -frontend -typecheck codexTestApp/*.swift` *(fails: no such module 'SwiftUI')*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf7cf6cec83308d228986d47639bb