### PR TITLE
Add AI deck generator using Foundation Models

### DIFF
--- a/codexTestApp/AICardGenerator.swift
+++ b/codexTestApp/AICardGenerator.swift
@@ -1,0 +1,25 @@
+import Foundation
+import FoundationModels
+
+@Generable
+struct AICard: Codable {
+    @Guide("Spanish word or phrase")
+    var spanish: String
+
+    @Guide("English translation of the word or phrase")
+    var english: String
+}
+
+actor AICardGenerator {
+    private let session = LanguageModelSession()
+
+    init() {
+        precondition(SystemLanguageModel.default.isAvailable, "Foundation Model not available—needs Apple Intelligence and compatible device")
+    }
+
+    func generateCards(count: Int) async throws -> [Flashcard] {
+        let prompt = "Generate \(count) Spanish English flashcards as short words or phrases."
+        let aiCards: [AICard] = try await session.respond(to: prompt, generating: [AICard].self)
+        return aiCards.map { Flashcard(spanish: $0.spanish, english: $0.english) }
+    }
+}

--- a/codexTestApp/HomeView.swift
+++ b/codexTestApp/HomeView.swift
@@ -4,6 +4,19 @@ struct HomeView: View {
     @State private var deckSize: Int = 10
     @State private var deck: Deck = Deck.randomDeck(size: 10)
     @State private var showDeck = false
+    @State private var isGenerating = false
+
+    private func generateAIDeck() async {
+        isGenerating = true
+        defer { isGenerating = false }
+        do {
+            let generator = AICardGenerator()
+            let cards = try await generator.generateCards(count: deckSize)
+            deck = Deck(cards: cards)
+        } catch {
+            print("Failed to generate cards: \(error)")
+        }
+    }
     
     var body: some View {
         NavigationView {
@@ -23,6 +36,16 @@ struct HomeView: View {
                         deck = Deck.randomDeck(size: deckSize)
                     }
                     .buttonStyle(.borderedProminent)
+
+                    if isGenerating {
+                        ProgressView()
+                    }
+
+                    Button("Generate AI Deck") {
+                        Task { await generateAIDeck() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isGenerating)
 
                     NavigationLink(destination: DeckView(deck: deck), isActive: $showDeck) {
                         EmptyView()


### PR DESCRIPTION
## Summary
- integrate FoundationModels for generating flashcards
- add `AICardGenerator` actor to ask the system language model for Spanish/English cards
- update `HomeView` with a button to create a deck using AI

## Testing
- `xcodebuild -list -project codexTestApp.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf9467c1083309e0047574dd996e8